### PR TITLE
readme fix for formatter option string->int

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ var Loggerr = require('loggerr'),
 var logger = new Loggerr({
 	formatter: function(date, level, data) {
 		var color;
-		switch(level) {
+		switch(Loggerr.levels.indexOf(level)) {
 			case Loggerr.EMERGENCY:
 			case Loggerr.ALERT:
 			case Loggerr.CRITICAL:


### PR DESCRIPTION
Confused me for a bit when setting this up. The cli formatter has it right, its just the readme that's not up to date.