### PR TITLE
fix!: support bundlers like rollup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x, 13.x, 14.x]
+        node-version: [18.x, 20.x, 22.x]
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node-version }}

--- a/README.md
+++ b/README.md
@@ -166,3 +166,34 @@ new Loggerr({
   streams: Loggerr.levels.map(() => logfile)
 })
 ```
+
+## Bundling with Rollup
+
+There is a dynamic require in this library. If you intend to use this with a bundler (ex Rollup) you may need to configure it to include the correct formatter if you pass that
+option as a string (ex `formatter: 'cli'`).
+
+Example:
+
+```javascript
+// rollup.config.js
+const { nodeResolve } = require('@rollup/plugin-node-resolve');
+const commonjs = require('@rollup/plugin-commonjs');
+
+module.exports = {
+  input: 'index.js',
+  output: {
+    file: 'bundle.js',
+    format: 'commonjs'
+  },
+  plugins: [
+    nodeResolve(),
+    commonjs({
+      dynamicRequireTargets: [
+        './node_modules/loggerr/formatters/cli.js',
+      ]
+    })
+  ]
+};
+```
+
+The values above will change based on your application, but the main important thing is the `dynamicRequireTargets` configuration.

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function Loggerr (options) {
   // Setup formatter
   let formatter = opts.formatter || Loggerr.defaultOptions.formatter
   if (typeof formatter === 'string') {
-    formatter = require(`${__dirname}/formatters/${formatter}`)
+    formatter = require(`./formatters/${formatter}.js`)
   }
   this.formatter = formatter
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "standard && npm run examples && mocha",
     "test:debug": "mocha --inspect --inspect-brk --timeout=0",
     "test:cover": "c8 mocha",
+    "test:only": "mocha",
     "examples": "for i in examples/*; do echo \"\n======-----======\n  $i\n======-----======\n\"; node \"$i\"; done",
     "release": "npm t && standard-version && npm publish",
     "postpublish": "git push && git push --tags"
@@ -34,8 +35,11 @@
     "chalk": "^4.1.0"
   },
   "devDependencies": {
+    "@rollup/plugin-commonjs": "^26.0.1",
+    "@rollup/plugin-node-resolve": "^15.2.3",
     "c8": "^7.3.0",
     "mocha": "^6.2.0",
+    "rollup": "^4.19.0",
     "standard": "^13.1.0",
     "standard-version": "^9.0.0"
   }

--- a/test/bundler.js
+++ b/test/bundler.js
@@ -1,0 +1,39 @@
+'use strict'
+const { describe, it } = require('mocha')
+const assert = require('node:assert')
+const path = require('node:path')
+const vm = require('node:vm')
+const { rollup } = require('rollup')
+
+describe('Bundlers', () => {
+  it('should bundle with rollup', async () => {
+    const bundle = await rollup({
+      input: {
+        main: path.join(__dirname, '..', 'examples', 'cli')
+      },
+      plugins: [
+        require('@rollup/plugin-node-resolve')(),
+        require('@rollup/plugin-commonjs')({
+          dynamicRequireTargets: [
+            path.join(__dirname, '..', 'formatters', 'cli.js')
+          ]
+        })
+      ]
+    })
+
+    assert(bundle.watchFiles.includes(path.join(__dirname, '..', 'examples', 'cli.js')))
+    assert(bundle.watchFiles.includes(path.join(__dirname, '..', 'formatters', 'cli.js')))
+
+    const { output } = await bundle.generate({
+      format: 'cjs'
+    })
+    await bundle.close()
+
+    vm.runInThisContext(`
+      ;((require, module) => {
+        ${output[0].code};
+        return module;
+      });
+    `)(require, {})
+  })
+})


### PR DESCRIPTION
The dynamic require and the `__dirname` created difficulties with bundlers like rollup. This change does not *resolve* the issue as it still requires dynamic import configuration, ~but it is a non-breaking way to get this to work~ (the change is non-breaking but the new dev dep *is*, so instead of keeping the old test matrix and doing a minor I am just going to rev the major).