### PR TITLE
feat: add writeLevel to write unformatted logs while respecting level

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,13 @@ const log = new Loggerr({
 })
 ```
 
+### Unformatted/Pre-formatted logging
+
+If you need to write raw logs without formatting there are two options:
+
+1. `writeLevel(level, msg, done)`: Will respect logging `level` but skip all formatting
+2. `write(level, msg, done)`: Will write logs regardless of `level` and skip all formatting
+
 ## Output Streams
 
 You can output each level to it's own stream. The method is simple, just pass an

--- a/index.d.ts
+++ b/index.d.ts
@@ -182,6 +182,19 @@ declare namespace DefaultLoggerr {
       msg: Uint8Array | string,
       done?: () => void,
     ): void;
+
+    /**
+     * Writes to a stream if level is satisfied
+     * 
+     * @param level Level 
+     * @param msg Message
+     * @param done "Done" callback
+     */
+    writeLevel(
+      level: LevelRef<T>,
+      msg: Uint8Array | string,
+      done?: () => void,
+    ): void;
   } & {
     [key in T[number]]: LogFunction;
   }

--- a/index.js
+++ b/index.js
@@ -131,6 +131,23 @@ Loggerr.prototype.log = function (level, msg, extra, done) {
 }
 
 /**
+ * Write with level awareness
+ */
+Loggerr.prototype.writeLevel = function (level, msg, done) {
+  const i = this.levels.indexOf(level)
+  if (
+    typeof level !== 'string' ||
+    i > this.level ||
+    !this.streams[i]
+  ) {
+    return
+  }
+
+  // Write out the message
+  this._write(this.streams[i], msg, 'utf8', done)
+}
+
+/**
  * Write to the given level stream
  */
 Loggerr.prototype.write = function (level, msg, done) {
@@ -182,7 +199,6 @@ function processMessage (level, msg, extra, formatter) {
 
   return formatter(new Date(), level, data)
 }
-
 function ErrorContext (err, extra) {
   if (!(err instanceof Error)) {
     err = new Error(err)

--- a/test/index.js
+++ b/test/index.js
@@ -12,7 +12,9 @@ describe('Logger - basic', function () {
     it(util.format('should log %s messages', level), function (done) {
       const w = writer(function (chunk, encoding, next) {
         assert.notStrictEqual(chunk.indexOf('foo'), -1, util.format('"%s" does not contain foo', chunk))
-        done()
+        if (typeof next === 'function') {
+          next()
+        }
       })
 
       const logger = new Logger({
@@ -21,8 +23,12 @@ describe('Logger - basic', function () {
       })
       if (Logger.levels[i + 1]) {
         logger[Logger.levels[i + 1]]('bar')
+        logger.writeLevel(Logger.levels[i + 1], 'bar')
       }
       logger[Logger.levels[i]]('foo')
+      logger.writeLevel(Logger.levels[i], 'foo', () => {
+        done()
+      })
     })
   })
 

--- a/test/types.ts
+++ b/test/types.ts
@@ -53,6 +53,11 @@ expect.expectTypeOf<(typeof newDefaultLoggerr)['level']>().toMatchTypeOf<
   Indices<DefaultLevels>
 >();
 
+expect.expectTypeOf(newDefaultLoggerr.writeLevel('info', 'message')).toEqualTypeOf<void>();
+expect.expectTypeOf(newDefaultLoggerr.writeLevel('info', 'message', () => {})).toEqualTypeOf<void>();
+// @ts-expect-error - no such level
+expect.expectTypeOf(newDefaultLoggerr.writeLevel('silly', 'message')).toEqualTypeOf<void>();
+
 expect.expectTypeOf<
   (typeof newDefaultLoggerr)['debug']
 >().toMatchTypeOf<LogFunction>();


### PR DESCRIPTION
Adds `writeLevel` with the same signature as `write`, but it additionally checks the `level`. This can be used to write "pass through" logs where you don't want any of the processing/formatting to be applied while *also* respecting the current instances `.level`.