### PR TITLE
feat: add debugStream option for optionally capturing all logs regardless of level

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,21 @@ new Loggerr({
 })
 ```
 
+### Debug Stream
+
+You can also pass a `debugStream` which will receive all logs regardless of level. This is helpful when you want to send
+logs to a file which you can use in error reporting or debugging failures.
+
+```javascript
+new Loggerr({
+  debugStream: fs.createWriteStream('./logs/debug.log', {
+    flags: 'a',
+    encoding: 'utf8'
+  })
+})
+
+```
+
 ## Bundling with Rollup
 
 There is a dynamic require in this library. If you intend to use this with a bundler (ex Rollup) you may need to configure it to include the correct formatter if you pass that

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,7 @@ type DefaultOptions = Readonly<{
   level: LoggerrConstructor['WARNING'];
   formatter: DefaultLoggerr.FormatterFunction;
   streams: DefaultStreams;
+  debugStream?: WritableStreamLike
 }>;
 
 /**


### PR DESCRIPTION
Allow for sending all logs to an alternate stream for having a debug file with all logs.