### PR TITLE
feat: improved output when logging self

### DIFF
--- a/examples/self.js
+++ b/examples/self.js
@@ -1,0 +1,9 @@
+'use strict'
+const log = require('../')
+log.warning('self', { log })
+
+const cliLog = new log.Loggerr({
+  formatter: 'cli',
+  level: 'info'
+})
+cliLog.warning('self', { log })

--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@
 
 'use strict'
 
+const customInspectSymbol = Symbol.for('nodejs.util.inspect.custom')
+
 /**
  * Loggerr constructor
  */
@@ -155,6 +157,21 @@ Loggerr.prototype.write = function (level, msg, done) {
 
   // Write out the message
   this._write(this.streams[i], msg, 'utf8', done)
+}
+
+/**
+ * Setup a custom inspect for nodejs to prevent bad logging
+ * when logging an instance of the logger itself
+ */
+Loggerr.prototype[customInspectSymbol] = function (depth, inspectOptions, inspect) {
+  const out = this.constructor.name
+  if (depth < 0) {
+    return out
+  }
+  return `${out} ${inspect({ ...this }, {
+    ...inspectOptions,
+    depth: 1
+  })}`
 }
 
 /**


### PR DESCRIPTION
This limits what the logger logs about itself to what users *may* need to see. It used to recurse into the streams and that was super noisy. This basically forces `depth: 1` for any `Loggerr` instances. 